### PR TITLE
fix: remove duplicate "resolve" key in config

### DIFF
--- a/chapter2/wp5_test/packages/nav/webpack.config.js
+++ b/chapter2/wp5_test/packages/nav/webpack.config.js
@@ -9,9 +9,6 @@ module.exports = {
   output: {
     publicPath: "http://localhost:3001/",
   },
-  resolve: {
-    extensions: [".jsx", ".js", ".json"],
-  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Remove duplicate "resolve" key in the webpack.config.js of nav